### PR TITLE
Replace last WHERE clause with the aggregate instead of appending it

### DIFF
--- a/DefaultSqlQueryBuilder/Extensions/SqlClauseExtensions.cs
+++ b/DefaultSqlQueryBuilder/Extensions/SqlClauseExtensions.cs
@@ -63,10 +63,11 @@ namespace DefaultSqlQueryBuilder.Extensions
 				.Cast<WhereSqlClause>()
 				.ToArray();
 
-			if (removableWhereClauses.Any())
+			if (removableWhereClauses.Count() > 1)
 			{
+				int lastWhereClause = clauses.FindLastIndex(clause => clause is WhereSqlClause);
+				clauses[lastWhereClause] = removableWhereClauses.Aggregate(MergeWhere);
 				clauses.RemoveAll(removableWhereClauses.Contains);
-				clauses.Add(removableWhereClauses.Aggregate(MergeWhere));
 			}
 
 			return clauses;


### PR DESCRIPTION
This will replace the last WhereSqlClause instance in the list with the aggregate instead
of appending the aggregate to the list.
This process is skipped when there is only one WHERE clause.
Fixes #1